### PR TITLE
Handle terraform destroy and recreate

### DIFF
--- a/examples/example-with-mssql-kms/README.md
+++ b/examples/example-with-mssql-kms/README.md
@@ -1,0 +1,15 @@
+1. Create a database using KMS Key A.
+2. Run terraform destroy
+3. Run terraform apply
+4. Change the database to use Key B
+5. Run terraform apply
+
+This will cause a -/+ plan which destroys the database and then recreates it.
+
+The lambdas will run for up to 16 minutes while the database is destroyed.  Then they will correctly update the finalsnapshot.
+
+Note that apply will keep destroying/creating the database as you cannot change a key in this way!
+
+See https://aws.amazon.com/premiumsupport/knowledge-center/update-encryption-key-rds/
+
+

--- a/examples/example-with-mssql-kms/main.tf
+++ b/examples/example-with-mssql-kms/main.tf
@@ -46,12 +46,19 @@ resource "aws_db_instance" "database" {
   final_snapshot_identifier = "${module.snapshot_maintenance.final_snapshot_identifier}"
   backup_retention_period = 0
 
-  kms_key_id                = "${aws_kms_key.this.arn}"
+  kms_key_id                = "${aws_kms_key.a.arn}"
   storage_encrypted         = true
 }
 
-resource "aws_kms_key" "this" {
+resource "aws_kms_key" "a" {
  description             = "database storage encryption key"
  deletion_window_in_days = "10"
+ enable_key_rotation     = true
+}
+
+resource "aws_kms_key" "b" {
+ description             = "database storage encryption key"
+ deletion_window_in_days = "10"
+ enable_key_rotation     = true
 }
 

--- a/modules/rds_snapshot_maintenance_lambda/main.tf
+++ b/modules/rds_snapshot_maintenance_lambda/main.tf
@@ -83,6 +83,7 @@ resource "aws_lambda_function" "find-final-snapshot" {
   handler = "find_final_snapshot.handler"
   source_code_hash = "${data.archive_file.find-final-snapshot-zip.0.output_base64sha256}"
   runtime = "python2.7"
+  timeout = 300
   description = "MANAGED BY TERRAFORM"
 }
 


### PR DESCRIPTION
If you change a property of an aws_db_instance which is destructive, then terraform will create a plan with a `+/-` indicator; and will destroy the database and then recreate it.

The problem is that the snapshot identifiers do not update in this scenario, so you will end up with an error stating that it cannot create a duplicate final snapshot modifier.

This modification will properly maintain the final snapshot counter provided the database is backed up within 16 minutes.

This works because the Lambda now detects when the snapshot is being created and waits up to 4 minutes. Lambdas have a maximum time limit of 5 minutes.  
So the Lambda is executed 4 times.

The other change here is the Lambda is run on EVERY apply, which is untidy.

It may be possible to modify this so that it is only run on destructive apply by identifying all things which are destructive changes - and then passing them in to the lambda inputs instead of the `${timestamp()}`


